### PR TITLE
Add Docker Support for Anny (CPU & GPU Builds + Gradio Demo)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,65 @@
+# =========================================================
+# Base (shared configuration)
+# =========================================================
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DEFAULT_TIMEOUT=120 \
+    GRADIO_SERVER_NAME=0.0.0.0 \
+    GRADIO_SERVER_PORT=7860
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    git wget ca-certificates build-essential \
+    libgl1 libglib2.0-0 \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# =========================================================
+# Minimal (CPU-only) — includes warp + examples
+# =========================================================
+FROM base AS minimal
+
+ENV OMP_NUM_THREADS=2
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip && \
+    pip install --no-cache-dir "gradio>=4" && \
+    pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.4.1 && \
+    pip install --no-cache-dir "scipy" && \
+    pip install --no-cache-dir "anny[warp,examples]@git+https://github.com/naver/anny.git"
+
+EXPOSE 7860
+CMD ["python", "-m", "anny.examples.interactive_demo"]
+
+# =========================================================
+# Full (GPU + Warp) — lightweight CUDA runtime base
+# =========================================================
+FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04 AS full
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DEFAULT_TIMEOUT=120 \
+    GRADIO_SERVER_NAME=0.0.0.0 \
+    GRADIO_SERVER_PORT=7860
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    python3 python3-pip python3-venv git wget ca-certificates build-essential \
+    libgl1 libglib2.0-0 \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cu121 torch==2.4.1 && \
+    python3 -m pip install --no-cache-dir "gradio>=4" && \
+    python3 -m pip install --no-cache-dir "anny[warp,examples]@git+https://github.com/naver/anny.git"
+
+EXPOSE 7860
+CMD ["python3", "-m", "anny.examples.interactive_demo"]
+

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -1,0 +1,169 @@
+# 🧠 Anny — Dockerized Human Body Mesh Model
+
+**Anny** is a differentiable human body mesh model written in **PyTorch**. It models a broad spectrum of human body shapes—from infants to elders—using a shared topology and parameter space.
+
+This Docker setup provides a clean, production-ready environment for running **Anny** locally, supporting both **CPU-only** and **GPU (CUDA + Warp)** builds.
+
+---
+
+## 🚀 Overview
+
+| Build Target       | GPU Support   | Base Image                               | Approx. Size | Recommended For                          |
+| :----------------- | :------------ | :--------------------------------------- | :----------- | :--------------------------------------- |
+| **`anny-minimal`** | ❌ CPU-only    | `python:3.11-slim`                       | ~1.8 GB      | Systems without NVIDIA GPU               |
+| **`anny-full`**    | ✅ CUDA + Warp | `nvidia/cuda:12.1.1-runtime-ubuntu22.04` | ~2.3 GB      | Workstations or servers with NVIDIA GPUs |
+
+---
+
+## 🧩 Prerequisites
+
+### For All Builds
+
+* **Docker** ≥ 24.0
+* **Docker Compose** v2.3 or newer
+* Internet access for image and dependency downloads
+
+### For GPU (Full) Build
+
+* **NVIDIA GPU** with driver ≥ 525
+* **NVIDIA Container Toolkit** installed
+* Test GPU access:
+
+  ```bash
+  nvidia-smi
+  ```
+
+If this shows your GPU and driver info, you’re ready to build the GPU version.
+
+---
+
+## ⚙️ Build Instructions
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/naver/anny.git
+cd anny
+```
+
+### 2. Enable BuildKit for faster builds
+
+```bash
+export DOCKER_BUILDKIT=1
+```
+
+### 3. Build the Docker Images
+
+**CPU-only (minimal)**:
+
+```bash
+docker compose build anny-minimal
+```
+
+**GPU-enabled (full)**:
+
+```bash
+docker compose build anny-full
+```
+
+---
+
+## ▶️ Run the Demo
+
+### CPU-only Demo
+
+```bash
+docker compose up anny-minimal
+```
+
+Access the demo at: [http://localhost:7860](http://localhost:7860)
+
+### GPU + Warp Demo
+
+```bash
+docker compose up anny-full
+```
+
+Access the demo at: [http://localhost:7860](http://localhost:7860)
+
+> ⚠️ Ensure NVIDIA runtime is properly configured (`docker run --gpus all ...` should work).
+
+---
+
+## 🧠 Validation
+
+Once the container is running, validate Torch and Warp inside:
+
+**Check PyTorch GPU availability:**
+
+```bash
+docker exec -it anny-full python3 -c "import torch; print(torch.__version__, 'CUDA?', torch.cuda.is_available())"
+```
+
+**Expected output:**
+
+```
+2.4.1 CUDA? True
+```
+
+**Check Warp installation:**
+
+```bash
+docker exec -it anny-full python3 -c "import warp; print('Warp OK:', warp.__version__)"
+```
+
+---
+
+## 🧾 Helpful Commands
+
+| Action          | Command                             |
+| :-------------- | :---------------------------------- |
+| Build CPU image | `docker compose build anny-minimal` |
+| Build GPU image | `docker compose build anny-full`    |
+| Run CPU demo    | `docker compose up anny-minimal`    |
+| Run GPU demo    | `docker compose up anny-full`       |
+| Stop containers | `docker compose down`               |
+| Rebuild clean   | `docker compose build --no-cache`   |
+
+---
+
+## 🧰 Troubleshooting
+
+| Issue                          | Cause                     | Solution                                  |
+| ------------------------------ | ------------------------- | ----------------------------------------- |
+| `ModuleNotFoundError: trimesh` | Missing demo deps         | Fixed via `[examples]` extras in build    |
+| `warp` import fails            | No NVIDIA runtime         | Install NVIDIA Container Toolkit          |
+| Port not reachable             | Firewall or port conflict | Ensure port 7860 is free                  |
+| Slow build                     | No pip cache              | Use BuildKit (`export DOCKER_BUILDKIT=1`) |
+
+---
+
+## 🧩 Tech Stack
+
+* **Python** 3.11
+* **PyTorch** 2.4.1 (CPU / CUDA 12.1)
+* **Gradio** ≥ 4.0
+* **Warp-lang** (for GPU builds)
+* **Anny** (with `examples` extras)
+
+---
+
+## 🪪 License
+
+* **Anny** © 2025 NAVER Corp. — Licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+* **MakeHuman assets** (MPFB2) — Licensed under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)
+
+---
+
+## 🧡 Credits
+
+* [NAVER AI Lab — Anny](https://github.com/naver/anny)
+* [MakeHuman Community](http://www.makehumancommunity.org/)
+* [NVIDIA Container Toolkit](https://developer.nvidia.com/container-runtime)
+
+---
+
+### ✨ Maintained Dockerized Setup
+
+Created for easy local deployment, demonstration, and experimentation with Anny using modern container practices.
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "3.9"
+
+services:
+  anny-minimal:
+    container_name: anny-minimal
+    build:
+      context: .
+      target: minimal
+    ports:
+      - "7860:7860"
+    environment:
+      GRADIO_SERVER_NAME: "0.0.0.0"
+      GRADIO_SERVER_PORT: "7860"
+      OMP_NUM_THREADS: "2"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:7860/ || exit 1"]
+      interval: 30s        # check every 30 seconds
+      timeout: 10s         # wait up to 10 seconds per check
+      start_period: 180s   # give Anny 3 minutes to load first
+      retries: 5           # retry 5 times before marking unhealthy
+
+
+  anny-full:
+    container_name: anny-full
+    build:
+      context: .
+      target: full             # uses the GPU + warp stage from Dockerfile
+    ports:
+      - "7860:7860"
+    environment:
+      GRADIO_SERVER_NAME: "0.0.0.0"
+      GRADIO_SERVER_PORT: "7860"
+    # For Docker Compose v2+, this enables GPU access (requires nvidia-container-toolkit)
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+    # If your Compose doesn't honor 'deploy' locally, uncomment one of the two lines below:
+    # gpus: all                      # (Compose v2.3+)
+    # runtime: nvidia                # (older Docker setups)
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:7860/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      start_period: 180s
+      retries: 3
+


### PR DESCRIPTION
[anny_docker_pr.md](https://github.com/user-attachments/files/23421906/anny_docker_pr.md)



**Introduced a complete Docker setup to simplify Anny installation and demo usage.

- Added multi-stage Dockerfile for CPU-only and GPU (CUDA 12.1) builds.
- Included docker-compose.yml for easy startup and health checks.
- Added Docker-README.md with build/run documentation.
- Preinstalled warp-lang, scipy, and trimesh for full model functionality.

The new setup allows running the interactive Gradio demo at http://localhost:7860
without manual dependency setup or environment conflicts.**